### PR TITLE
Add ability to use the DNA string as the filename

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,8 @@ const preview = {
 
 const useRandomName = false;
 
+const encodeFileName = true;
+
 module.exports = {
   format,
   baseUri,
@@ -64,5 +66,6 @@ module.exports = {
   shuffleLayerConfigurations,
   debugLogs,
   extraMetadata,
-  useRandomName
+  useRandomName,
+  encodeFileName,
 };


### PR DESCRIPTION
Add ability to use the DNA string as the filename for the .png and .json files instead of sequential numbers. Do this using the encodeFileName flag in the config.json file and setting it to true.